### PR TITLE
Th/api update

### DIFF
--- a/packages/nouns-api/src/api.ts
+++ b/packages/nouns-api/src/api.ts
@@ -45,8 +45,8 @@ export const createAPI = (): Express => {
   app.post('/login', AuthController.login);
   app.get('/idea/:id', IdeasController.getIdeaById);
   app.get('/idea/:id/votes', IdeasController.getVotesByIdea);
-  app.post('/idea/comment', IdeasController.commentOnIdea);
-  app.post('/idea/vote', IdeasController.voteOnIdea);
+  app.post('/idea/comment', authMiddleware, IdeasController.commentOnIdea);
+  app.post('/idea/vote', authMiddleware, IdeasController.voteOnIdea);
   app.get('/ideas', IdeasController.getAllIdeas);
   app.post('/ideas', authMiddleware, IdeasController.createIdea);
 

--- a/packages/nouns-api/src/controllers/ideas.ts
+++ b/packages/nouns-api/src/controllers/ideas.ts
@@ -35,7 +35,7 @@ class IdeasController {
 
   static createIdea = async (req: Request, res: Response, next: any) => {
     try {
-      const idea = await IdeasService.createIdea(req.body);
+      const idea = await IdeasService.createIdea(req.body, req.user);
       res.status(200).json({
         status: true,
         message: 'Idea created',
@@ -50,7 +50,7 @@ class IdeasController {
 
   static voteOnIdea = async (req: Request, res: Response, next: any) => {
     try {
-      const idea = await IdeasService.voteOnIdea(req.body);
+      const idea = await IdeasService.voteOnIdea(req.body, req.user);
       res.status(200).json({
         status: true,
         message: 'Voted on idea',
@@ -65,7 +65,7 @@ class IdeasController {
 
   static commentOnIdea = async (req: Request, res: Response, next: any) => {
     try {
-      const idea = await IdeasService.commentOnIdea(req.body);
+      const idea = await IdeasService.commentOnIdea(req.body, req.user);
       res.status(200).json({
         status: true,
         message: 'Commented on idea',

--- a/packages/nouns-api/src/middlewares/auth.ts
+++ b/packages/nouns-api/src/middlewares/auth.ts
@@ -1,29 +1,38 @@
-import { verifyAccessToken } from "../utils/jwt";
+import { verifyAccessToken } from '../utils/jwt';
 import { Request, Response } from 'express';
 
 const authMiddleware = async (req: Request, res: Response, next: any) => {
   if (!req.headers.authorization) {
-    return res.status(401).json({
-      message: 'Unauthorized: Auth Header missing'
-    }).end();
+    return res
+      .status(401)
+      .json({
+        message: 'Unauthorized: Auth Header missing',
+      })
+      .end();
   }
 
-  const token = req.headers.authorization.split(' ')[1]
-  if (!token || token === "undefined") {
-    return res.status(401).json({
-      message: 'Unauthorized: Access token is required'
-    }).end();
+  const token = req.headers.authorization.split(' ')[1];
+  if (!token || token === 'undefined') {
+    return res
+      .status(401)
+      .json({
+        message: 'Unauthorized: Access token is required',
+      })
+      .end();
   }
 
   try {
     const user: any = await verifyAccessToken(token);
-    req.user = user
-    next()
-  } catch(e) {
-    res.status(401).json({
-      message: 'Unauthorized: Failed to validate token',
-    }).end()
+    req.user = user.payload;
+    next();
+  } catch (e) {
+    res
+      .status(401)
+      .json({
+        message: 'Unauthorized: Failed to validate token',
+      })
+      .end();
   }
-}
+};
 
-export default authMiddleware
+export default authMiddleware;

--- a/packages/nouns-api/src/services/ideas.ts
+++ b/packages/nouns-api/src/services/ideas.ts
@@ -1,5 +1,4 @@
 import { prisma } from '../api';
-import { User } from '@prisma/client';
 
 class IdeasService {
   static async all() {
@@ -20,14 +19,17 @@ class IdeasService {
     return idea;
   }
 
-  static async createIdea(data: any) {
+  static async createIdea(data: any, user?: { wallet: string }) {
     try {
+      if (!user) {
+        throw new Error('Failed to save idea: missing user details');
+      }
       const idea = await prisma.idea.create({
         data: {
           title: data.title,
           tldr: data.tldr,
           description: data.description,
-          creatorId: '0x65A3870F48B5237f27f674Ec42eA1E017E111D63',
+          creatorId: user.wallet,
         },
       });
 
@@ -38,12 +40,15 @@ class IdeasService {
     }
   }
 
-  static async voteOnIdea(data: any) {
+  static async voteOnIdea(data: any, user?: { wallet: string }) {
     try {
+      if (!user) {
+        throw new Error('Failed to save vote: missing user details');
+      }
       const vote = prisma.vote.upsert({
         where: {
           ideaId_voterId: {
-            voterId: data.voterAddress,
+            voterId: user.wallet,
             ideaId: data.ideaId,
           },
         },
@@ -52,7 +57,7 @@ class IdeasService {
         },
         create: {
           direction: data.direction,
-          voterId: data.voterAddress,
+          voterId: user.wallet,
           ideaId: data.ideaId,
         },
       });
@@ -79,12 +84,16 @@ class IdeasService {
     }
   }
 
-  static async commentOnIdea(data: any) {
+  static async commentOnIdea(data: any, user?: { wallet: string }) {
     try {
+      if (!user) {
+        throw new Error('Failed to save comment: missing user details');
+      }
+
       const comment = prisma.comment.create({
         data: {
           body: data.body,
-          authorId: data.authorId,
+          authorId: user.wallet,
           ideaId: data.ideaId,
         },
       });

--- a/packages/nouns-api/typing-stubs/express/index.d.ts
+++ b/packages/nouns-api/typing-stubs/express/index.d.ts
@@ -1,7 +1,7 @@
 declare namespace Express {
   interface Request {
     user?: {
-      wallet?: string;
+      wallet: string;
     };
   }
 }

--- a/packages/nouns-webapp/src/components/IdeaCard/index.tsx
+++ b/packages/nouns-webapp/src/components/IdeaCard/index.tsx
@@ -23,7 +23,6 @@ const IdeaCard = ({ idea }) => {
     const v = await voteOnIdea({
       direction: dir,
       ideaId: id,
-      voterAddress: account,
     });
     mutate('http://localhost:5001/ideas');
   };

--- a/packages/nouns-webapp/src/hooks/useIdeas.ts
+++ b/packages/nouns-webapp/src/hooks/useIdeas.ts
@@ -11,7 +11,6 @@ interface IdeaFormData {
 interface VoteFormData {
   direction: number;
   ideaId: number;
-  voterAddress: string;
 }
 
 export const useIdeas = () => {

--- a/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
+++ b/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
@@ -44,7 +44,6 @@ const IdeaPage = () => {
     const v = await voteOnIdea({
       direction: dir,
       ideaId: parseInt(id),
-      voterAddress: account,
     });
     IdeaAPI.revalidateVotes(id);
   };
@@ -56,7 +55,6 @@ const IdeaPage = () => {
   const submitComment = async () => {
     const response = await IdeaAPI.commentOnIdea({
       body: comment,
-      authorId: account,
       ideaId: parseInt(id),
     });
     setComment('');


### PR DESCRIPTION
Small updates to the API code to add auth middleware to the POST routes. This allows us to extract the user wallet details from the auth token instead of clients sending the value down in the payload (less secure).

Just beware that adding the auth middleware will mean you need to sign the transaction [(triggered by this button currently)](https://github.com/ThatTobMate/lilnouns-monorepo/blob/master/packages/nouns-webapp/src/components/Ideas/index.tsx#L49) first to vote + post comments + ideas successfully.