### PR TITLE
Th/add token weighted voting

### DIFF
--- a/packages/nouns-api/prisma/migrations/20220704080324_add_noun_count_to_user/migration.sql
+++ b/packages/nouns-api/prisma/migrations/20220704080324_add_noun_count_to_user/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `lilnounCount` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "lilnounCount" INTEGER NOT NULL;

--- a/packages/nouns-api/prisma/migrations/20220704142933_add_vote_count_to_idea/migration.sql
+++ b/packages/nouns-api/prisma/migrations/20220704142933_add_vote_count_to_idea/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `voteCount` to the `Idea` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Idea" ADD COLUMN     "voteCount" INTEGER NOT NULL;

--- a/packages/nouns-api/prisma/schema.prisma
+++ b/packages/nouns-api/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   ideas    Idea[]
   votes    Vote[]
   comments Comment[]
+  lilnounCount Int
 }
 
 // direction

--- a/packages/nouns-api/prisma/schema.prisma
+++ b/packages/nouns-api/prisma/schema.prisma
@@ -21,6 +21,7 @@ model Idea {
   creatorId   String
   comments    Comment[]
   votes       Vote[]
+  voteCount   Int
 }
 
 model User {

--- a/packages/nouns-api/prisma/seed.ts
+++ b/packages/nouns-api/prisma/seed.ts
@@ -21,6 +21,7 @@ async function seed() {
         tldr: chance.sentence({ words: 5 }),
         description: chance.sentence({ words: 10 }),
         creatorId: user.wallet,
+        voteCount: 0,
       },
     });
   }

--- a/packages/nouns-api/prisma/seed.ts
+++ b/packages/nouns-api/prisma/seed.ts
@@ -9,6 +9,7 @@ async function seed() {
     id: 1,
     wallet: '0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9',
     ens: 'test.eth',
+    lilnounCount: 3,
   };
 
   await prisma.user.create({ data: user });

--- a/packages/nouns-api/src/controllers/auth.ts
+++ b/packages/nouns-api/src/controllers/auth.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 
 import AuthService from '../services/auth';
 import { SiweMessage } from 'siwe';
+import { nounTokenCount } from '../utils/utils';
 
 class AuthController {
   static register = async (req: Request, res: Response, next: any) => {
@@ -59,14 +60,16 @@ class AuthController {
         });
       }
 
+      const lilnounCount = 2 || nounTokenCount(fields.address);
+
       // This isn't working but we want to run it to ensure the user has nouns before we auth them.
 
-      // if (!hasNounToken(fields.address)) {
+      // if (!lilNounsCount) {
       // console.log('Failed to fetch votes')
       // return next(new createError.Unauthorized(`User does not have a lil noun`))
       // }
 
-      const data = await AuthService.login({ wallet: fields.address });
+      const data = await AuthService.login({ wallet: fields.address, lilnounCount });
       res.status(200).json({
         status: true,
         message: 'Account login successful',

--- a/packages/nouns-api/src/controllers/auth.ts
+++ b/packages/nouns-api/src/controllers/auth.ts
@@ -60,6 +60,7 @@ class AuthController {
         });
       }
 
+      // FIX BEFORE LAUNCH
       const lilnounCount = 2 || nounTokenCount(fields.address);
 
       // This isn't working but we want to run it to ensure the user has nouns before we auth them.

--- a/packages/nouns-api/src/services/auth.ts
+++ b/packages/nouns-api/src/services/auth.ts
@@ -8,9 +8,25 @@ class AuthService {
       const user = await prisma.user.create({
         data,
       });
-      data.accessToken = await signAccessToken(user);
+      const accessToken = await signAccessToken(user);
 
-      return data;
+      return { ...user, accessToken };
+    } catch (e: any) {
+      throw e;
+    }
+  }
+
+  static async update(data: { wallet: string; lilnounCount: number }) {
+    const { wallet } = data;
+    try {
+      const user = await prisma.user.update({
+        where: {
+          wallet,
+        },
+        data,
+      });
+
+      return user;
     } catch (e: any) {
       throw e;
     }
@@ -24,10 +40,10 @@ class AuthService {
     }
   }
 
-  static async login(data: { wallet: string }) {
+  static async login(data: { wallet: string; lilnounCount: number }) {
     const { wallet } = data;
     try {
-      const user = await prisma.user.findUnique({
+      let user = await prisma.user.findUnique({
         where: {
           wallet,
         },
@@ -35,6 +51,8 @@ class AuthService {
 
       if (!user) {
         return this.register(data);
+      } else {
+        user = await this.update(data); // Could do this update async
       }
 
       const accessToken = await signAccessToken(user);

--- a/packages/nouns-api/src/services/ideas.ts
+++ b/packages/nouns-api/src/services/ideas.ts
@@ -1,11 +1,5 @@
 import { prisma } from '../api';
 
-const countVotes = (idea: any) => {
-  return idea.votes.reduce((sum: number, vote: any) => {
-    return (sum + vote.direction) * vote.voter.lilnounCount;
-  }, 0);
-};
-
 class IdeasService {
   static async all() {
     try {
@@ -17,12 +11,16 @@ class IdeasService {
             },
           },
         },
+        orderBy: [
+          {
+            voteCount: 'desc',
+          },
+          {
+            createdAt: 'asc',
+          },
+        ],
       });
-      const ideas = allIdeas.map((idea: any) => {
-        const voteCount = countVotes(idea);
-        return { ...idea, voteCount };
-      });
-      return ideas;
+      return allIdeas;
     } catch (e: any) {
       throw e;
     }
@@ -61,15 +59,13 @@ class IdeasService {
         throw new Error('Idea not found');
       }
 
-      const voteCount = countVotes(idea);
-
-      return { ...idea, voteCount };
+      return idea;
     } catch (e: any) {
       throw e;
     }
   }
 
-  static async createIdea(data: any, user?: { wallet: string }) {
+  static async createIdea(data: any, user?: { wallet: string; lilnounCount: number }) {
     try {
       if (!user) {
         throw new Error('Failed to save idea: missing user details');
@@ -80,6 +76,16 @@ class IdeasService {
           tldr: data.tldr,
           description: data.description,
           creatorId: user.wallet,
+          voteCount: user.lilnounCount,
+          votes: {
+            create: {
+              direction: 1,
+              voterId: user.wallet,
+            },
+          },
+        },
+        include: {
+          votes: true,
         },
       });
 
@@ -89,30 +95,73 @@ class IdeasService {
     }
   }
 
-  static async voteOnIdea(data: any, user?: { wallet: string }) {
+  static async voteOnIdea(data: any, user?: { wallet: string; lilnounCount: number }) {
     try {
       if (!user) {
         throw new Error('Failed to save vote: missing user details');
       }
-      const vote = prisma.vote.upsert({
+
+      // Find if the user has placed a vote on this idea already.
+      let vote = await prisma.vote.findUnique({
         where: {
           ideaId_voterId: {
             voterId: user.wallet,
             ideaId: data.ideaId,
           },
         },
-        update: {
-          direction: data.direction,
-        },
-        create: {
-          direction: data.direction,
-          voterId: user.wallet,
-          ideaId: data.ideaId,
-        },
-        include: {
-          voter: true,
-        },
       });
+
+      if (!vote) {
+        const [newVote, idea] = await prisma.$transaction([
+          prisma.vote.create({
+            data: {
+              direction: data.direction,
+              voterId: user.wallet,
+              ideaId: data.ideaId,
+            },
+            include: {
+              voter: true,
+              idea: true,
+            },
+          }),
+          prisma.idea.update({
+            where: {
+              id: data.ideaId,
+            },
+            data: {
+              voteCount: {
+                increment: data.direction * user.lilnounCount,
+              },
+            },
+          }),
+        ]);
+
+        vote = { ...newVote, idea } as any;
+      } else {
+        vote = await prisma.vote.update({
+          where: {
+            ideaId_voterId: {
+              voterId: user.wallet,
+              ideaId: data.ideaId,
+            },
+          },
+          data: {
+            direction: data.direction,
+            idea: {
+              update: {
+                voteCount: {
+                  // If the user has placed a vote before we want to double the weight of their new vote to override their existing vote.
+                  increment: data.direction * 2 * user.lilnounCount,
+                },
+              },
+            },
+          },
+          include: {
+            voter: true,
+            idea: true,
+          },
+        });
+      }
 
       return vote;
     } catch (e) {

--- a/packages/nouns-api/src/utils/utils.ts
+++ b/packages/nouns-api/src/utils/utils.ts
@@ -44,11 +44,11 @@ export const getTokenMetadata = async (tokenId: string): Promise<undefined | Tok
   return metadata;
 };
 
-export const hasNounToken = async (account: string) => {
+export const nounTokenCount = async (account: string) => {
   const data = await tryF(() => nounsTokenContract.getCurrentVotes(account));
   if (isError(data)) {
     console.error(`Error fetching votes for account ${account}: ${data.message}`);
     return;
   }
   return data.votes?.toNumber();
-}
+};

--- a/packages/nouns-api/typing-stubs/express/index.d.ts
+++ b/packages/nouns-api/typing-stubs/express/index.d.ts
@@ -2,6 +2,7 @@ declare namespace Express {
   interface Request {
     user?: {
       wallet: string;
+      lilNounsCount: number;
     };
   }
 }

--- a/packages/nouns-api/typing-stubs/express/index.d.ts
+++ b/packages/nouns-api/typing-stubs/express/index.d.ts
@@ -2,7 +2,7 @@ declare namespace Express {
   interface Request {
     user?: {
       wallet: string;
-      lilNounsCount: number;
+      lilnounCount: number;
     };
   }
 }

--- a/packages/nouns-webapp/src/components/IdeaCard/index.tsx
+++ b/packages/nouns-webapp/src/components/IdeaCard/index.tsx
@@ -42,7 +42,8 @@ const IdeaCard = ({
             id={id}
             votes={votes}
             voteOnIdea={voteOnIdea}
-            hasVotes={connectedAccountNounVotes > 0}
+            connectedAccountNounVotes={connectedAccountNounVotes}
+            voteCount={idea.voteCount}
           />
         </div>
       </div>

--- a/packages/nouns-webapp/src/components/IdeaVoteControls/index.tsx
+++ b/packages/nouns-webapp/src/components/IdeaVoteControls/index.tsx
@@ -7,32 +7,36 @@ const IdeaVoteControls = ({
   id,
   votes,
   voteOnIdea,
-  hasVotes,
+  connectedAccountNounVotes,
+  voteCount,
 }: {
   id: number;
   votes: Vote[];
   voteOnIdea: (args: any) => void;
-  hasVotes: boolean;
+  connectedAccountNounVotes: number;
+  voteCount: number;
 }) => {
   const { account } = useEthers();
+  const hasVotes = connectedAccountNounVotes > 0;
+
+  const usersVote = votes.find(vote => vote.voterId === account);
+  const userHasUpVote = usersVote && usersVote.direction === 1;
+  const userHasDownVote = usersVote && usersVote.direction === -1;
+
   const vote = (dir: number) =>
     voteOnIdea({
       direction: dir,
       ideaId: id,
       voterId: account,
+      voter: {
+        lilnounCount: connectedAccountNounVotes,
+      },
     });
-
-  const usersVote = votes.find(vote => vote.voterId === account);
-  const userHasUpVote = usersVote && usersVote.direction === 1;
-  const userHasDownVote = usersVote && usersVote.direction === -1;
-  const ideaScore = votes.reduce((sum, vote) => {
-    return sum + vote.direction;
-  }, 0);
 
   return (
     <>
       <span className="text-3xl text-black font-bold lodrina self-center justify-end">
-        {ideaScore}
+        {voteCount}
       </span>
       <div className="flex flex-col ml-4">
         <FontAwesomeIcon

--- a/packages/nouns-webapp/src/components/Ideas/index.tsx
+++ b/packages/nouns-webapp/src/components/Ideas/index.tsx
@@ -6,7 +6,7 @@ import { useUserVotes } from '../../wrappers/nounToken';
 import classes from './Ideas.module.css';
 import { isMobileScreen } from '../../utils/isMobile';
 import IdeaCard from '../IdeaCard';
-import { useIdeas } from '../../hooks/useIdeas';
+import { Idea, useIdeas } from '../../hooks/useIdeas';
 
 const Ideas = () => {
   const { account } = useEthers();
@@ -50,7 +50,7 @@ const Ideas = () => {
       {isMobile && <div className={classes.nullStateCopy}>{nullStateCopy()}</div>}
       {ideas?.length ? (
         <span className="space-y-4">
-          {ideas.map((idea, i) => {
+          {ideas.map((idea: Idea, i) => {
             return (
               <IdeaCard
                 idea={idea}

--- a/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
+++ b/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
@@ -161,7 +161,8 @@ const IdeaPage = () => {
                 id={idea.id}
                 votes={idea.votes}
                 voteOnIdea={castVote}
-                hasVotes={connectedAccountNounVotes > 0}
+                connectedAccountNounVotes={connectedAccountNounVotes}
+                voteCount={idea.voteCount}
               />
             </div>
           </div>


### PR DESCRIPTION
- Store lil noun token count against the user record when they register or log in via signing the transaction.

- Use the user lil noun token count to calculate the weighted votes based on their vote direction on an idea.
  - When a user has previously voted we update the existing vote record to change the direction value, then we update the associated Idea voteCount with this formula `idea.voteCount + vote.direction * 2 * user.lilnounCount`. We multiply by 2 to counter their previous vote. i.e. if they downvoted with 2 tokens leaving a post at -2 votes, then we need to double their effective token count if they change their vote in the other direction so that the votes sit at 2 instead of 0.
  - This should be more scalable as it enables us to introduce pagination if we need to. Calculating these client side and having sorting means we'd have to always fetch all ideas in the initial response.

- Order the ideas list on the API by the voteCount property

- Update the useIdeas hook and client code to make use of the voteCount property instead of calculating the score on the client.