### PR TITLE
Fix nouns contract check for votes on auth

### DIFF
--- a/packages/nouns-api/src/controllers/auth.ts
+++ b/packages/nouns-api/src/controllers/auth.ts
@@ -60,17 +60,15 @@ class AuthController {
         });
       }
 
-      // FIX BEFORE LAUNCH
-      const lilnounCount = 2 || nounTokenCount(fields.address);
+      // For local dev set NOUNS_TOKEN_ADDRESS to `0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9`
+      const lilnounCount = await nounTokenCount(fields.address);
 
-      // This isn't working but we want to run it to ensure the user has nouns before we auth them.
-
-      // if (!lilNounsCount) {
-      // console.log('Failed to fetch votes')
-      // return next(new createError.Unauthorized(`User does not have a lil noun`))
-      // }
+      if (!(lilnounCount > 0)) {
+        throw new Error(`User does not have a lil noun`);
+      }
 
       const data = await AuthService.login({ wallet: fields.address, lilnounCount });
+
       res.status(200).json({
         status: true,
         message: 'Account login successful',

--- a/packages/nouns-api/src/utils/utils.ts
+++ b/packages/nouns-api/src/utils/utils.ts
@@ -50,5 +50,5 @@ export const nounTokenCount = async (account: string) => {
     console.error(`Error fetching votes for account ${account}: ${data.message}`);
     return;
   }
-  return data.votes?.toNumber();
+  return data?.toNumber();
 };


### PR DESCRIPTION
Small PR that fixes the nouns contract check for votes on auth. You need to set the `NOUNS_TOKEN_ADDRESS` env to `0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9` locally to make this work. You'll also want to ensure you're logged in with a dev wallet that has lil nouns.