### PR TITLE
Add contract event listener on express API

### DIFF
--- a/packages/nouns-api/src/controllers/auth.ts
+++ b/packages/nouns-api/src/controllers/auth.ts
@@ -100,6 +100,14 @@ class AuthController {
         .end();
     }
   };
+
+  static syncUserTokenCounts = async (to: string, from: string) => {
+    try {
+      await AuthService.syncUserTokenCounts(to, from);
+    } catch (e: any) {
+      console.log(e);
+    }
+  };
 }
 
 export default AuthController;

--- a/packages/nouns-api/src/services/auth.ts
+++ b/packages/nouns-api/src/services/auth.ts
@@ -51,7 +51,7 @@ class AuthService {
       if (!user) {
         user = await this.register(data);
       } else {
-        user = await this.update(data); // Could do this update async
+        user = await this.update(data);
       }
 
       const accessToken = await signAccessToken(user);
@@ -63,6 +63,37 @@ class AuthService {
   static async all() {
     const allUsers = await prisma.user.findMany();
     return allUsers;
+  }
+
+  static async syncUserTokenCounts(to: string, from: string) {
+    try {
+      const toUser = await prisma.user.findUnique({
+        where: {
+          wallet: to,
+        },
+      });
+
+      const fromUser = await prisma.user.findUnique({
+        where: {
+          wallet: from,
+        },
+      });
+
+      if (!fromUser && !toUser) {
+        console.log('No Users To Update');
+        return;
+      }
+
+      if (toUser) {
+        await this.update({ wallet: to, lilnounCount: toUser.lilnounCount + 1 });
+      }
+
+      if (fromUser) {
+        await this.update({ wallet: to, lilnounCount: fromUser.lilnounCount - 1 });
+      }
+    } catch (e: any) {
+      console.log(e);
+    }
   }
 }
 

--- a/packages/nouns-api/src/services/ideas.ts
+++ b/packages/nouns-api/src/services/ideas.ts
@@ -94,7 +94,10 @@ class IdeasService {
     }
   }
 
-  static async createIdea(data: { title: string, tldr: string, description: string }, user?: { wallet: string }) {
+  static async createIdea(
+    data: { title: string; tldr: string; description: string },
+    user?: { wallet: string },
+  ) {
     try {
       if (!user) {
         throw new Error('Failed to save idea: missing user details');

--- a/packages/nouns-webapp/src/components/IdeaCard/index.tsx
+++ b/packages/nouns-webapp/src/components/IdeaCard/index.tsx
@@ -7,7 +7,6 @@ import { useReverseENSLookUp } from '../../utils/ensLookup';
 import { useShortAddress } from '../ShortAddress';
 
 import IdeaVoteControls from '../IdeaVoteControls';
-import { useUserVotes } from '../../wrappers/nounToken';
 
 const IdeaCard = ({
   idea,
@@ -24,7 +23,7 @@ const IdeaCard = ({
 
   const ens = useReverseENSLookUp(creatorId);
   const shortAddress = useShortAddress(creatorId);
-  const creatorLilNoun = useUserVotes(creatorId);
+  const creatorLilNoun = votes.find(vote => vote.voterId === creatorId)?.voter?.lilnounCount;
 
   return (
     <div

--- a/packages/nouns-webapp/src/wrappers/nounToken.ts
+++ b/packages/nouns-webapp/src/wrappers/nounToken.ts
@@ -48,15 +48,14 @@ export const useNounSeed = (nounId: EthersBN) => {
   return seed;
 };
 
-export const useUserVotes = (accountOverride?: string): number | undefined => {
+export const useUserVotes = (): number | undefined => {
   const { account } = useEthers();
-  const args = accountOverride ? [accountOverride] : [account];
   const [votes] =
     useContractCall<[EthersBN]>({
       abi,
       address: config.addresses.nounsToken,
       method: 'getCurrentVotes',
-      args,
+      args: [account],
     }) || [];
   return votes?.toNumber();
 };


### PR DESCRIPTION
Add contract event listener for noun token transfers to update user records lilnounCount. We use this count to calculate token weighted voting so we want to keep the values relatively up to date, we can listen to the contract events to do this.