### PR TITLE
Th/update noun token check

### DIFF
--- a/packages/nouns-api/src/utils/utils.ts
+++ b/packages/nouns-api/src/utils/utils.ts
@@ -45,7 +45,7 @@ export const getTokenMetadata = async (tokenId: string): Promise<undefined | Tok
 };
 
 export const nounTokenCount = async (account: string) => {
-  const data = await tryF(() => nounsTokenContract.getCurrentVotes(account));
+  const data = await tryF(() => nounsTokenContract.balanceOf(account));
   if (isError(data)) {
     console.error(`Error fetching votes for account ${account}: ${data.message}`);
     return;

--- a/packages/nouns-webapp/src/components/IdeaCard/index.tsx
+++ b/packages/nouns-webapp/src/components/IdeaCard/index.tsx
@@ -11,11 +11,11 @@ import IdeaVoteControls from '../IdeaVoteControls';
 const IdeaCard = ({
   idea,
   voteOnIdea,
-  connectedAccountNounVotes,
+  nounBalance,
 }: {
   idea: Idea;
   voteOnIdea: (formData: VoteFormData) => void;
-  connectedAccountNounVotes: number;
+  nounBalance: number;
 }) => {
   const history = useHistory();
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -42,7 +42,7 @@ const IdeaCard = ({
           <IdeaVoteControls
             id={id}
             voteOnIdea={voteOnIdea}
-            connectedAccountNounVotes={connectedAccountNounVotes}
+            nounBalance={nounBalance}
             voteCount={voteCount}
             votes={votes}
             withAvatars

--- a/packages/nouns-webapp/src/components/IdeaVoteControls/index.tsx
+++ b/packages/nouns-webapp/src/components/IdeaVoteControls/index.tsx
@@ -8,19 +8,19 @@ const IdeaVoteControls = ({
   id,
   votes,
   voteOnIdea,
-  connectedAccountNounVotes,
+  nounBalance,
   voteCount,
   withAvatars = false,
 }: {
   id: number;
   votes: Vote[];
   voteOnIdea: (args: any) => void;
-  connectedAccountNounVotes: number;
+  nounBalance: number;
   voteCount: number;
   withAvatars?: boolean;
 }) => {
   const { account, library: provider } = useEthers();
-  const hasVotes = connectedAccountNounVotes > 0;
+  const hasVotes = nounBalance > 0;
 
   const usersVote = votes?.find(vote => vote.voterId === account);
   const userHasUpVote = usersVote?.direction === 1;
@@ -32,7 +32,7 @@ const IdeaVoteControls = ({
       ideaId: id,
       voterId: account,
       voter: {
-        lilnounCount: connectedAccountNounVotes,
+        lilnounCount: nounBalance,
       },
     });
 

--- a/packages/nouns-webapp/src/components/Ideas/index.tsx
+++ b/packages/nouns-webapp/src/components/Ideas/index.tsx
@@ -2,9 +2,8 @@ import { Alert, Button, Form } from 'react-bootstrap';
 import { useEthers } from '@usedapp/core';
 import { useHistory } from 'react-router-dom';
 import clsx from 'clsx';
-import { useUserVotes } from '../../wrappers/nounToken';
+import { useNounTokenBalance } from '../../wrappers/nounToken';
 import classes from './Ideas.module.css';
-import { isMobileScreen } from '../../utils/isMobile';
 import IdeaCard from '../IdeaCard';
 import { Idea, useIdeas, SORT_BY } from '../../hooks/useIdeas';
 
@@ -19,18 +18,16 @@ const Ideas = () => {
     setSortBy(e.target.value);
   };
 
-  const connectedAccountNounVotes = useUserVotes() || 0;
-
-  const isMobile = isMobileScreen();
+  const nounBalance = useNounTokenBalance(account || undefined) ?? 0;
 
   const nullStateCopy = () => {
-    if (account !== null) {
+    if (Boolean(account)) {
       return 'You have no Lil Nouns.';
     }
     return 'Connect wallet to submit an idea.';
   };
 
-  const hasNouns = connectedAccountNounVotes > 0;
+  const hasNouns = nounBalance > 0;
 
   return (
     <div>
@@ -62,7 +59,9 @@ const Ideas = () => {
           )}
         </div>
       </div>
-      <div className={classes.nullStateCopy}>{nullStateCopy()}</div>
+      {(!Boolean(account) || !hasNouns) && (
+        <div className={classes.nullStateCopy}>{nullStateCopy()}</div>
+      )}
       {ideas?.length ? (
         <span className="space-y-4">
           {ideas.map((idea: Idea, i) => {
@@ -71,7 +70,7 @@ const Ideas = () => {
                 idea={idea}
                 key={`idea-${idea.id}`}
                 voteOnIdea={voteOnIdeaList}
-                connectedAccountNounVotes={connectedAccountNounVotes}
+                nounBalance={nounBalance}
               />
             );
           })}

--- a/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
+++ b/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
@@ -14,7 +14,7 @@ import {
   Comment as CommentType,
   VoteFormData,
 } from '../../../hooks/useIdeas';
-import { useUserVotes } from '../../../wrappers/nounToken';
+import { useNounTokenBalance } from '../../../wrappers/nounToken';
 import IdeaVoteControls from '../../../components/IdeaVoteControls';
 import moment from 'moment';
 import Davatar from '@davatar/react';
@@ -26,11 +26,13 @@ const linkRenderer = renderer.link;
 renderer.link = (href, title, text) => {
   const localLink = href?.startsWith(`${location.protocol}//${location.hostname}`);
   const html = linkRenderer.call(renderer, href, title, text);
-  return localLink ? html : html.replace(/^<a /, `<a target="_blank" rel="noreferrer noopener nofollow" `);
+  return localLink
+    ? html
+    : html.replace(/^<a /, `<a target="_blank" rel="noreferrer noopener nofollow" `);
 };
 
 marked.setOptions({
-  renderer: renderer
+  renderer: renderer,
 });
 
 const Comment = ({
@@ -148,7 +150,7 @@ const IdeaPage = () => {
   const history = useHistory();
   const { account } = useEthers();
   const [comment, setComment] = useState<string>();
-  const connectedAccountNounVotes = useUserVotes() || 0;
+  const nounBalance = useNounTokenBalance(account || undefined) ?? 0;
 
   const { getIdea, getComments, commentOnIdea, voteOnIdea } = useIdeas();
 
@@ -172,7 +174,7 @@ const IdeaPage = () => {
     setComment('');
   };
 
-  const hasNouns = connectedAccountNounVotes > 0;
+  const hasNouns = nounBalance > 0;
 
   return (
     <Section fullWidth={false} className={classes.section}>
@@ -193,7 +195,7 @@ const IdeaPage = () => {
               <IdeaVoteControls
                 id={idea.id}
                 voteOnIdea={castVote}
-                connectedAccountNounVotes={connectedAccountNounVotes}
+                nounBalance={nounBalance}
                 voteCount={idea.votecount}
                 votes={idea.votes}
               />
@@ -207,7 +209,13 @@ const IdeaPage = () => {
           </div>
           <div className="flex flex-col">
             <h3 className="lodrina font-bold text-2xl mb-2">Description</h3>
-            <div dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(marked.parse(idea.description), { ADD_ATTR: ['target'] })}} />
+            <div
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(marked.parse(idea.description), {
+                  ADD_ATTR: ['target'],
+                }),
+              }}
+            />
           </div>
         </div>
 


### PR DESCRIPTION
We had previously been using the `useUserVotes` hook to check for the balance of a users lil nouns. We don't really care about a users lil nouns voting rights and instead want to allow anyone with lil nouns access to contributing.

This PR updates the checks to use the `balanceOf` contract call instead.