### PR TITLE
Add Sentry APM

### DIFF
--- a/packages/nouns-api/package.json
+++ b/packages/nouns-api/package.json
@@ -33,6 +33,8 @@
   "dependencies": {
     "@nouns/contracts": "^0.1.3",
     "@prisma/client": "^3.15.2",
+    "@sentry/node": "^7.7.0",
+    "@sentry/tracing": "^7.7.0",
     "@types/chance": "^1.1.3",
     "@types/jsonwebtoken": "^8.5.8",
     "chance": "^1.1.8",

--- a/packages/nouns-api/src/api.ts
+++ b/packages/nouns-api/src/api.ts
@@ -1,5 +1,6 @@
+import * as Sentry from '@sentry/node';
+import * as Tracing from '@sentry/tracing';
 import express, { Express, Request, Response } from 'express';
-
 import AuthController from './controllers/auth';
 import bodyParser from 'body-parser';
 import IdeasController from './controllers/ideas';
@@ -29,12 +30,39 @@ export const rollbar = new Rollbar({
  */
 export const createAPI = (): Express => {
   const app = express();
+  Sentry.init({
+    dsn: config.sentryDSN,
+    integrations: [
+      // enable HTTP calls tracing
+      new Sentry.Integrations.Http({ tracing: true }),
+      // enable Express.js middleware tracing
+      new Tracing.Integrations.Express({ app }),
+      new Tracing.Integrations.Prisma({ client: prisma }),
+    ],
+
+    // Set tracesSampleRate to 1.0 to capture 100%
+    // of transactions for performance monitoring.
+    // We recommend adjusting this value in production
+    tracesSampleRate: 0.75,
+  });
+
   app.use(express.json());
 
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(bodyParser.json());
 
   app.use(cors());
+
+  app.use((req, res, next) => {
+    Sentry.setUser({ ip_address: '{{auto}}' });
+    next();
+  });
+
+  // RequestHandler creates a separate execution context using domains, so that every
+  // transaction/span/breadcrumb is attached to its own Hub instance
+  app.use(Sentry.Handlers.requestHandler());
+  // TracingHandler creates a trace for every incoming request
+  app.use(Sentry.Handlers.tracingHandler());
 
   app.get('/', (_req, res) => {
     res.status(200).send({

--- a/packages/nouns-api/src/clients.ts
+++ b/packages/nouns-api/src/clients.ts
@@ -1,18 +1,6 @@
 import { config } from './config';
 import { Contract, providers } from 'ethers';
-import { NFTStorage } from 'nft.storage';
 import { NounsTokenABI } from '@nouns/contracts';
-import Redis from 'ioredis';
-
-/**
- * IFPS Storage Client
- */
-export const storage = new NFTStorage({ token: config.nftStorageApiKey });
-
-/**
- * Redis Client
- */
-export const redis = new Redis(config.redisPort, config.redisHost);
 
 /**
  * Ethers JSON RPC Provider

--- a/packages/nouns-api/src/config.ts
+++ b/packages/nouns-api/src/config.ts
@@ -11,4 +11,5 @@ export const config = {
   nftStorageApiKey:
     process.env.NFT_STORAGE_API_KEY ??
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweDI1NjA0ZTA0YTkxYzcwOGM0MTU2OGZCRTcwMWVjNzVDY2IyMEM3MDciLCJpc3MiOiJuZnQtc3RvcmFnZSIsImlhdCI6MTYyNDgxNDkxNzE4NCwibmFtZSI6Im5vdW5zIn0.f3D9WFLQv4fNGBivXMtbXiKK0ta_UN5RRS_eZCiNLJY',
+  sentryDSN: process.env.SENTRY_DSN ?? '',
 };

--- a/packages/nouns-api/src/index.ts
+++ b/packages/nouns-api/src/index.ts
@@ -1,8 +1,8 @@
 import dotenv from 'dotenv';
+dotenv.config();
+
 import { createServer } from './server';
 import { createAPI } from './api';
-
-dotenv.config();
 
 const app = createAPI();
 

--- a/packages/nouns-api/src/middlewares/auth.ts
+++ b/packages/nouns-api/src/middlewares/auth.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/node';
+
 import { verifyAccessToken } from '../utils/jwt';
 import { Request, Response } from 'express';
 
@@ -24,6 +26,7 @@ const authMiddleware = async (req: Request, res: Response, next: any) => {
   try {
     const user: any = await verifyAccessToken(token);
     req.user = user.payload;
+    Sentry.setUser({ username: user.payload.wallet, ip_address: '{{auto}}' });
     next();
   } catch (e) {
     res

--- a/packages/nouns-api/src/utils/utils.ts
+++ b/packages/nouns-api/src/utils/utils.ts
@@ -1,48 +1,5 @@
-import { nounsTokenContract, redis, storage } from '../clients';
-import { TokenMetadata } from '../types';
+import { nounsTokenContract } from '../clients';
 import { tryF, isError } from 'ts-try';
-import sharp from 'sharp';
-
-/**
- * Get the token metadata cache key
- * @param tokenId The token ID
- */
-export const getMetadataKey = (tokenId: string): string => `metadata_${tokenId}`;
-
-/**
- * Get the token metadata for the provided `tokenId`
- * @param tokenId The token ID
- */
-export const getTokenMetadata = async (tokenId: string): Promise<undefined | TokenMetadata> => {
-  const key = getMetadataKey(tokenId);
-  const cachedMetadata = await redis.get(key);
-
-  if (cachedMetadata) {
-    return JSON.parse(cachedMetadata);
-  }
-
-  const dataURI = await tryF(() => nounsTokenContract.dataURI(tokenId));
-  if (isError(dataURI)) {
-    console.error(`Error fetching dataURI for token ID ${tokenId}: ${dataURI.message}`);
-    return;
-  }
-
-  const data: TokenMetadata = JSON.parse(
-    Buffer.from(dataURI.substring(29), 'base64').toString('ascii'),
-  );
-  const svg = Buffer.from(data.image.substring(26), 'base64');
-  const png = await sharp(svg).png().toBuffer();
-  const imageCID = await storage.storeBlob(png as any);
-
-  const metadata = {
-    name: data.name,
-    description: data.description,
-    image: `ipfs://${imageCID}`,
-  };
-  await redis.set(key, JSON.stringify(metadata));
-
-  return metadata;
-};
 
 export const nounTokenCount = async (account: string) => {
   const data = await tryF(() => nounsTokenContract.balanceOf(account));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4671,6 +4671,16 @@
     "@sentry/utils" "5.30.0"
     tslib "^1.9.3"
 
+"@sentry/core@7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.7.0.tgz#1a2d477897552d179380f7c54c7d81a4e98ea29a"
+  integrity sha512-Z15ACiuiFINFcK4gbMrnejLn4AVjKBPJOWKrrmpIe8mh+Y9diOuswt5mMUABs+jhpZvqht3PBLLGBL0WMsYMYA==
+  dependencies:
+    "@sentry/hub" "7.7.0"
+    "@sentry/types" "7.7.0"
+    "@sentry/utils" "7.7.0"
+    tslib "^1.9.3"
+
 "@sentry/hub@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.30.0.tgz#2453be9b9cb903404366e198bd30c7ca74cdc100"
@@ -4678,6 +4688,15 @@
   dependencies:
     "@sentry/types" "5.30.0"
     "@sentry/utils" "5.30.0"
+    tslib "^1.9.3"
+
+"@sentry/hub@7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.7.0.tgz#9ad3471cf5ecaf1a9d3a3a04ca2515ffec9e2c09"
+  integrity sha512-6gydK234+a0nKhBRDdIJ7Dp42CaiW2juTiHegUVDq+482balVzbZyEAmESCmuzKJhx5BhlCElVxs/cci1NjMpg==
+  dependencies:
+    "@sentry/types" "7.7.0"
+    "@sentry/utils" "7.7.0"
     tslib "^1.9.3"
 
 "@sentry/minimal@5.30.0":
@@ -4704,6 +4723,20 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
+"@sentry/node@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.7.0.tgz#d39e904968fcca8cb0a881dee81887a6abf3ad74"
+  integrity sha512-i62x23NHEhLe6CJ6l9E30uRCUMm0VMz9aUmmrjW+9uxS1mZhHTG2kpbU16ozyh9KTLswKDOSE75Z+MzQpGSQ/Q==
+  dependencies:
+    "@sentry/core" "7.7.0"
+    "@sentry/hub" "7.7.0"
+    "@sentry/types" "7.7.0"
+    "@sentry/utils" "7.7.0"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
 "@sentry/tracing@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-5.30.0.tgz#501d21f00c3f3be7f7635d8710da70d9419d4e1f"
@@ -4715,10 +4748,25 @@
     "@sentry/utils" "5.30.0"
     tslib "^1.9.3"
 
+"@sentry/tracing@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.7.0.tgz#67324b755a28e115289755e44a0b8b467a63d0b2"
+  integrity sha512-HNmvTwemuc21q/K6HXsSp9njkne6N1JQ71TB+QGqYU5VtxsVgYSUhhYqV6WcHz7LK4Hj6TvNFoeu69/rO0ysgw==
+  dependencies:
+    "@sentry/hub" "7.7.0"
+    "@sentry/types" "7.7.0"
+    "@sentry/utils" "7.7.0"
+    tslib "^1.9.3"
+
 "@sentry/types@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.30.0.tgz#19709bbe12a1a0115bc790b8942917da5636f402"
   integrity sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==
+
+"@sentry/types@7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.7.0.tgz#dd6bd3d119d7efea0e85dbaa4b17de1c22b63c7a"
+  integrity sha512-4x8O7uerSGLnYC10krHl9t8h7xXHn5FextqKYbTCXCnx2hC8D+9lz8wcbQAFo0d97wiUYqI8opmEgFVGx7c5hQ==
 
 "@sentry/utils@5.30.0":
   version "5.30.0"
@@ -4726,6 +4774,14 @@
   integrity sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==
   dependencies:
     "@sentry/types" "5.30.0"
+    tslib "^1.9.3"
+
+"@sentry/utils@7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.7.0.tgz#013e3097c4268a76de578494c7df999635fb0ad4"
+  integrity sha512-fD+ROSFpeJlK7bEvUT2LOW7QqgjBpXJwVISKZ0P2fuzclRC3KoB2pbZgBM4PXMMTiSzRGWhvfRRjBiBvQJBBJQ==
+  dependencies:
+    "@sentry/types" "7.7.0"
     tslib "^1.9.3"
 
 "@sinclair/typebox@^0.23.3":


### PR DESCRIPTION
Adding Sentry as a APM monitoring service. Not using Sentry for error logs due to the free plan allowing a lot less errors than Rollbar.

Sentry as a APM will give us insights to the number of requests for each route and the performance of each route.

<img width="1378" alt="Screenshot 2022-07-24 at 15 41 52" src="https://user-images.githubusercontent.com/7782211/180652264-62cbcd0d-ee09-4171-b171-daac18d0689e.png">
