### PR TITLE
Th/add vote mutation

### DIFF
--- a/packages/nouns-api/src/graphql/generated.ts
+++ b/packages/nouns-api/src/graphql/generated.ts
@@ -69,6 +69,16 @@ export type IdeaTags = {
   type: TagType;
 };
 
+export type Mutation = {
+  __typename?: 'Mutation';
+  submitIdeaVote: Idea;
+};
+
+
+export type MutationSubmitIdeaVoteArgs = {
+  options: SubmitVoteInputOptions;
+};
+
 export type PropLotFilter = {
   __typename?: 'PropLotFilter';
   id: Scalars['String'];
@@ -126,6 +136,11 @@ export enum Sort_Type {
   VotesAsc = 'VOTES_ASC',
   VotesDesc = 'VOTES_DESC'
 }
+
+export type SubmitVoteInputOptions = {
+  direction: Scalars['Int'];
+  ideaId: Scalars['Int'];
+};
 
 export enum TagType {
   Archived = 'ARCHIVED',
@@ -240,6 +255,7 @@ export type ResolversTypes = {
   IdeaStats: ResolverTypeWrapper<IdeaStats>;
   IdeaTags: ResolverTypeWrapper<IdeaTags>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
+  Mutation: ResolverTypeWrapper<{}>;
   PropLotFilter: ResolverTypeWrapper<PropLotFilter>;
   PropLotInputOptions: PropLotInputOptions;
   PropLotResponse: ResolverTypeWrapper<PropLotResponse>;
@@ -247,6 +263,7 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   SORT_TYPE: Sort_Type;
   String: ResolverTypeWrapper<Scalars['String']>;
+  SubmitVoteInputOptions: SubmitVoteInputOptions;
   TagType: TagType;
   User: ResolverTypeWrapper<User>;
   UserInputOptions: UserInputOptions;
@@ -264,12 +281,14 @@ export type ResolversParentTypes = {
   IdeaStats: IdeaStats;
   IdeaTags: IdeaTags;
   Int: Scalars['Int'];
+  Mutation: {};
   PropLotFilter: PropLotFilter;
   PropLotInputOptions: PropLotInputOptions;
   PropLotResponse: PropLotResponse;
   PropLotResponseMetadata: PropLotResponseMetadata;
   Query: {};
   String: Scalars['String'];
+  SubmitVoteInputOptions: SubmitVoteInputOptions;
   User: User;
   UserInputOptions: UserInputOptions;
   UserStats: UserStats;
@@ -320,6 +339,10 @@ export type IdeaTagsResolvers<ContextType = any, ParentType extends ResolversPar
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['TagType'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  submitIdeaVote?: Resolver<ResolversTypes['Idea'], ParentType, ContextType, RequireFields<MutationSubmitIdeaVoteArgs, 'options'>>;
 };
 
 export type PropLotFilterResolvers<ContextType = any, ParentType extends ResolversParentTypes['PropLotFilter'] = ResolversParentTypes['PropLotFilter']> = {
@@ -381,6 +404,7 @@ export type Resolvers<ContextType = any> = {
   Idea?: IdeaResolvers<ContextType>;
   IdeaStats?: IdeaStatsResolvers<ContextType>;
   IdeaTags?: IdeaTagsResolvers<ContextType>;
+  Mutation?: MutationResolvers<ContextType>;
   PropLotFilter?: PropLotFilterResolvers<ContextType>;
   PropLotResponse?: PropLotResponseResolvers<ContextType>;
   PropLotResponseMetadata?: PropLotResponseMetadataResolvers<ContextType>;

--- a/packages/nouns-api/src/graphql/schemas/schema.graphql
+++ b/packages/nouns-api/src/graphql/schemas/schema.graphql
@@ -5,6 +5,10 @@ type Query {
   getPropLot(options: PropLotInputOptions!): PropLotResponse!
 }
 
+type Mutation {
+  submitIdeaVote(options: SubmitVoteInputOptions!): Vote!
+}
+
 # Query input types
 
 input UserInputOptions {
@@ -13,6 +17,11 @@ input UserInputOptions {
 
 input IdeaInputOptions {
   sort: SORT_TYPE
+}
+
+input SubmitVoteInputOptions {
+  direction: Int!
+  ideaId: Int!
 }
 
 input PropLotInputOptions {

--- a/packages/nouns-webapp/src/components/Ideas/index.tsx
+++ b/packages/nouns-webapp/src/components/Ideas/index.tsx
@@ -32,7 +32,6 @@ const Ideas = () => {
   return (
     <div>
       <div>
-        <h3 className={classes.heading}>Ideas</h3>
         <div className={clsx('d-flex', classes.submitIdeaButtonWrapper)}>
           {ideas?.length > 0 && (
             <div className={classes.sortFilter}>

--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -163,7 +163,7 @@ const NavBar = () => {
               <>
                 <Nav.Link as={Link} to="/ideas" className={classes.nounsNavLink}>
                   <NavBarButton
-                    buttonText={'Ideas'}
+                    buttonText={'Prop Lot'}
                     buttonIcon={<FontAwesomeIcon icon={faLightbulb} />}
                     buttonStyle={nonWalletButtonStyle}
                   />

--- a/packages/nouns-webapp/src/hooks/useAuth.tsx
+++ b/packages/nouns-webapp/src/hooks/useAuth.tsx
@@ -95,6 +95,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
       const one_hour = new Date(new Date().getTime() + 3600 * 1000);
       Cookies.set('lil-noun-token', data.data.accessToken, { expires: one_hour });
+
+      return data;
     } catch (e: any) {
       setError({ message: e.message || 'Login Failed', status: e.status });
       throw e;

--- a/packages/nouns-webapp/src/propLot/components/IdeaRow/index.tsx
+++ b/packages/nouns-webapp/src/propLot/components/IdeaRow/index.tsx
@@ -1,7 +1,5 @@
-// COPIED FROM IDEA CARD COMPONENT
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { VoteFormData } from '../../../hooks/useIdeas';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowAltCircleRight } from '@fortawesome/free-solid-svg-icons';
 import { useReverseENSLookUp } from '../../../utils/ensLookup';
@@ -10,26 +8,13 @@ import { useShortAddress } from '../../../utils/addressAndENSDisplayUtils';
 import moment from 'moment';
 import { createBreakpoint } from 'react-use';
 
-import IdeaVoteControls from '../../../components/IdeaVoteControls';
+import IdeaVoteControls from '../IdeaVoteControls';
 
 import { getPropLot_propLot_ideas as Idea } from '../../graphql/__generated__/getPropLot';
 
 const useBreakpoint = createBreakpoint({ XL: 1440, L: 940, M: 650, S: 540 });
 
-/*
-    TODO:
-    - Add voting mutations to proplot schema to support voting
-*/
-
-const IdeaRow = ({
-  idea,
-  voteOnIdea,
-  nounBalance,
-}: {
-  idea: Idea;
-  voteOnIdea: (formData: VoteFormData) => void;
-  nounBalance: number;
-}) => {
+const IdeaRow = ({ idea, nounBalance }: { idea: Idea; nounBalance: number }) => {
   const breakpoint = useBreakpoint();
   const history = useHistory();
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -50,11 +35,11 @@ const IdeaRow = ({
         <div className="flex justify-self-end">
           <IdeaVoteControls
             id={id}
-            voteOnIdea={voteOnIdea}
             nounBalance={nounBalance}
             voteCount={voteCount}
             votes={votes || []}
             withAvatars={!isMobile}
+            refetchPropLotOnVote
           />
         </div>
       </div>
@@ -74,11 +59,11 @@ const IdeaRow = ({
       <div className="flex justify-self-end">
         <IdeaVoteControls
           id={id}
-          voteOnIdea={voteOnIdea}
           nounBalance={nounBalance}
           voteCount={voteCount}
           votes={votes || []}
           withAvatars={!isMobile}
+          refetchPropLotOnVote
         />
       </div>
     </div>

--- a/packages/nouns-webapp/src/propLot/components/IdeaVoteControls/index.tsx
+++ b/packages/nouns-webapp/src/propLot/components/IdeaVoteControls/index.tsx
@@ -1,0 +1,161 @@
+import { useEthers } from '@usedapp/core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCaretUp, faCaretDown, faCircleNotch } from '@fortawesome/free-solid-svg-icons';
+import Davatar from '@davatar/react';
+import { useApiError } from '../../../hooks/useApiError';
+import { useMutation } from '@apollo/client';
+
+import { useAuth } from '../../../hooks/useAuth';
+
+import propLotClient from '../../graphql/config';
+import { SUBMIT_VOTE_MUTATION } from '../../graphql/propLotMutations';
+
+import {
+  submitIdeaVote,
+  submitIdeaVote_submitIdeaVote as Vote,
+} from '../../graphql/__generated__/submitIdeaVote';
+import { useEffect, useState } from 'react';
+
+const IdeaVoteControls = ({
+  id,
+  votes,
+  nounBalance,
+  voteCount,
+  withAvatars = false,
+  refetchPropLotOnVote = false,
+}: {
+  id: number;
+  votes?: Vote[];
+  nounBalance: number;
+  voteCount: number;
+  withAvatars?: boolean;
+  refetchPropLotOnVote?: boolean;
+}) => {
+  const { account, library: provider } = useEthers();
+  const { getAuthHeader, isLoggedIn, triggerSignIn } = useAuth();
+  const { setError, error: errorModalVisible } = useApiError();
+  // Store voteCount in state that we can mutate for optimistic updates
+  const [calculatedVoteCount, setCalculatedVoteCount] = useState(voteCount);
+
+  const hasVotes = nounBalance > 0;
+
+  const [submitVoteMutation, { error, loading, data }] = useMutation<submitIdeaVote>(
+    SUBMIT_VOTE_MUTATION,
+    {
+      context: {
+        clientName: 'PropLot',
+      },
+      client: propLotClient,
+      refetchQueries: refetchPropLotOnVote ? ['getPropLot'] : [],
+    },
+  );
+
+  const getVoteMutationArgs = (direction: number) => ({
+    context: {
+      headers: {
+        ...getAuthHeader(),
+      },
+    },
+    variables: {
+      options: {
+        ideaId: id,
+        direction: direction,
+      },
+    },
+  });
+
+  const vote = async (direction: number) => {
+    if (!isLoggedIn()) {
+      try {
+        await triggerSignIn();
+        submitVoteMutation(getVoteMutationArgs(direction));
+      } catch (e) {}
+    } else {
+      submitVoteMutation(getVoteMutationArgs(direction));
+    }
+  };
+
+  const usersVote = votes?.find(vote => vote.voterId === account);
+  const userHasUpVote = (data?.submitIdeaVote?.direction || usersVote?.direction) === 1;
+  const userHasDownVote = (data?.submitIdeaVote?.direction || usersVote?.direction) === -1;
+
+  useEffect(() => {
+    if (error && !errorModalVisible) {
+      setError({ message: error?.message || 'Failed to vote', status: 500 });
+    }
+  }, [error]);
+
+  // Optimistic update of the voteCount for quick user feedback.
+  useEffect(() => {
+    if (data?.submitIdeaVote.ideaId === id) {
+      const voteResponse = data?.submitIdeaVote;
+      setCalculatedVoteCount(
+        calculatedVoteCount + voteResponse?.direction * 2 * (voteResponse?.voter.lilnounCount || 0),
+      );
+    }
+  }, [data]);
+
+  // // If optimistic updates become out of sync with the voteCount prop then reset
+  // // to the prop value which comes from the latest API response.
+  useEffect(() => {
+    if (calculatedVoteCount !== voteCount) {
+      setCalculatedVoteCount(voteCount);
+    }
+  }, [voteCount]);
+
+  const avatarVotes = withAvatars ? votes?.slice(0, 3) || [] : [];
+
+  return (
+    <>
+      {withAvatars && (
+        <span className="flex self-center justify-end pl-2">
+          {avatarVotes.map((vote, i) => (
+            <span className={i < avatarVotes.length - 1 ? '-mr-2' : ''}>
+              <Davatar size={32} address={vote.voterId} provider={provider} />
+            </span>
+          ))}
+        </span>
+      )}
+      <span className="text-3xl text-black font-bold lodrina self-center justify-end pl-2">
+        {loading ? (
+          <FontAwesomeIcon
+            icon={faCircleNotch}
+            className={`fa-spinner fa-spin text-md text-blue-500`}
+          />
+        ) : (
+          calculatedVoteCount
+        )}
+      </span>
+      <div className="flex flex-col ml-4">
+        <FontAwesomeIcon
+          icon={faCaretUp}
+          onClick={e => {
+            // this prevents the click from bubbling up and opening / closing the hidden section
+            e.stopPropagation();
+            if (hasVotes && !userHasUpVote && !loading) {
+              vote(1);
+            }
+          }}
+          className={`${loading ? 'fa-beat-fade' : ''} text-3xl cursor-pointer ${
+            hasVotes && userHasUpVote ? 'text-blue-500' : 'text-[#8c8d92]'
+          }`}
+        />
+
+        <FontAwesomeIcon
+          icon={faCaretDown}
+          onClick={e => {
+            e.stopPropagation();
+            if (hasVotes && !userHasDownVote && !loading) {
+              vote(-1);
+            }
+          }}
+          className={`${loading ? 'fa-beat-fade' : ''} text-3xl cursor-pointer ${
+            hasVotes && userHasDownVote ? 'text-red-500' : 'text-[#8c8d92]'
+          }`}
+        />
+      </div>
+    </>
+  );
+};
+
+export default IdeaVoteControls;

--- a/packages/nouns-webapp/src/propLot/graphql/__generated__/globalTypes.ts
+++ b/packages/nouns-webapp/src/propLot/graphql/__generated__/globalTypes.ts
@@ -17,6 +17,11 @@ export interface PropLotInputOptions {
   requestUUID: string;
 }
 
+export interface SubmitVoteInputOptions {
+  direction: number;
+  ideaId: number;
+}
+
 //==============================================================
 // END Enums and Input Objects
 //==============================================================

--- a/packages/nouns-webapp/src/propLot/graphql/__generated__/submitIdeaVote.ts
+++ b/packages/nouns-webapp/src/propLot/graphql/__generated__/submitIdeaVote.ts
@@ -1,0 +1,33 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { SubmitVoteInputOptions } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: submitIdeaVote
+// ====================================================
+
+export interface submitIdeaVote_submitIdeaVote_voter {
+  __typename: "User";
+  wallet: string;
+  lilnounCount: number;
+}
+
+export interface submitIdeaVote_submitIdeaVote {
+  __typename: "Vote";
+  id: number;
+  voterId: string;
+  ideaId: number;
+  direction: number;
+  voter: submitIdeaVote_submitIdeaVote_voter;
+}
+
+export interface submitIdeaVote {
+  submitIdeaVote: submitIdeaVote_submitIdeaVote;
+}
+
+export interface submitIdeaVoteVariables {
+  options: SubmitVoteInputOptions;
+}

--- a/packages/nouns-webapp/src/propLot/graphql/propLotMutations.ts
+++ b/packages/nouns-webapp/src/propLot/graphql/propLotMutations.ts
@@ -1,0 +1,16 @@
+import { gql } from '@apollo/client';
+
+export const SUBMIT_VOTE_MUTATION = gql`
+  mutation submitIdeaVote($options: SubmitVoteInputOptions!) {
+    submitIdeaVote(options: $options) {
+      id
+      voterId
+      ideaId
+      direction
+      voter {
+        wallet
+        lilnounCount
+      }
+    }
+  }
+`;

--- a/packages/nouns-webapp/src/propLot/graphql/proplot-schema.json
+++ b/packages/nouns-webapp/src/propLot/graphql/proplot-schema.json
@@ -4,7 +4,9 @@
     "queryType": {
       "name": "Query"
     },
-    "mutationType": null,
+    "mutationType": {
+      "name": "Mutation"
+    },
     "subscriptionType": null,
     "types": [
       {
@@ -139,6 +141,51 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "Mutation",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": [
+          {
+            "name": "submitIdeaVote",
+            "description": null,
+            "args": [
+              {
+                "name": "options",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SubmitVoteInputOptions",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Vote",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "UserInputOptions",
         "description": null,
@@ -197,6 +244,61 @@
             "deprecationReason": null
           }
         ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SubmitVoteInputOptions",
+        "description": null,
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ideaId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Int",
+        "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
         "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
@@ -601,17 +703,6 @@
         ],
         "inputFields": null,
         "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Int",
-        "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
-        "specifiedByUrl": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },


### PR DESCRIPTION
Updating the voting logic for V2 to use the GraphQL endpoint. I've duplicated the component into the propLot directory to avoid breaking the existing behaviour on the live site.

### In this PR:

#### API:

- Create submitIdeaVote mutation to handle voting on a idea. Ensure this mutation requires authentication in the resolver.

#### Web App

- Fetch and build submitIdeaVote mutation schema + types
- Duplicate the IdeaVoteControls component into the propLot directory
- Hook up the new IdeaVoteControls to use the submitIdeaVote mutation
- Add loading state when voting - Replace vote count with spinner until successful response for slow connections.
- Refactor PropLotHome to use useLazyQuery which prevents unneccessary queries when the component re-renders.

#### Loading state

<img width="781" alt="Screenshot 2022-10-08 at 20 33 19" src="https://user-images.githubusercontent.com/7782211/194725639-9d323723-26c9-4400-ba18-bb895c1c5f05.png">

