### PR TITLE
Th/time based archiving

### DIFF
--- a/packages/nouns-api/prisma/migrations/20221024145454_added_token_supply_on_create/migration.sql
+++ b/packages/nouns-api/prisma/migrations/20221024145454_added_token_supply_on_create/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Idea" ADD COLUMN     "tokenSupplyOnCreate" INTEGER DEFAULT 0;

--- a/packages/nouns-api/prisma/schema.prisma
+++ b/packages/nouns-api/prisma/schema.prisma
@@ -23,6 +23,7 @@ model Idea {
   votes       Vote[]
   votecount   Int       @default(value: 0) // Vote.direction * Vote.voter.lilnounCount
   tags        Tag[]
+  tokenSupplyOnCreate Int? @default(value: 0) // token supply at time of Idea creation.
 }
 
 model User {

--- a/packages/nouns-api/prisma/seed.ts
+++ b/packages/nouns-api/prisma/seed.ts
@@ -24,6 +24,7 @@ async function seed() {
         description: chance.sentence({ words: 10 }),
         creatorId: `0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9${i}`,
         votecount: 0,
+        tokenSupplyOnCreate: 7 * i,
       },
     });
 

--- a/packages/nouns-api/src/graphql/generated.ts
+++ b/packages/nouns-api/src/graphql/generated.ts
@@ -41,7 +41,9 @@ export enum FilterType {
 
 export type Idea = {
   __typename?: 'Idea';
+  archived: Scalars['Boolean'];
   comments?: Maybe<Array<Comment>>;
+  consensus?: Maybe<Scalars['Float']>;
   createdAt: Scalars['String'];
   creatorId: Scalars['String'];
   description: Scalars['String'];
@@ -262,6 +264,7 @@ export type ResolversTypes = {
   Comment: ResolverTypeWrapper<Comment>;
   FilterOption: ResolverTypeWrapper<FilterOption>;
   FilterType: FilterType;
+  Float: ResolverTypeWrapper<Scalars['Float']>;
   Idea: ResolverTypeWrapper<Idea>;
   IdeaInputOptions: IdeaInputOptions;
   IdeaStats: ResolverTypeWrapper<IdeaStats>;
@@ -288,6 +291,7 @@ export type ResolversParentTypes = {
   Boolean: Scalars['Boolean'];
   Comment: Comment;
   FilterOption: FilterOption;
+  Float: Scalars['Float'];
   Idea: Idea;
   IdeaInputOptions: IdeaInputOptions;
   IdeaStats: IdeaStats;
@@ -328,7 +332,9 @@ export type FilterOptionResolvers<ContextType = any, ParentType extends Resolver
 };
 
 export type IdeaResolvers<ContextType = any, ParentType extends ResolversParentTypes['Idea'] = ResolversParentTypes['Idea']> = {
+  archived?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   comments?: Resolver<Maybe<Array<ResolversTypes['Comment']>>, ParentType, ContextType>;
+  consensus?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   creatorId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/nouns-api/src/graphql/generated.ts
+++ b/packages/nouns-api/src/graphql/generated.ts
@@ -41,7 +41,7 @@ export enum FilterType {
 
 export type Idea = {
   __typename?: 'Idea';
-  archived: Scalars['Boolean'];
+  closed: Scalars['Boolean'];
   comments?: Maybe<Array<Comment>>;
   consensus?: Maybe<Scalars['Float']>;
   createdAt: Scalars['String'];
@@ -332,7 +332,7 @@ export type FilterOptionResolvers<ContextType = any, ParentType extends Resolver
 };
 
 export type IdeaResolvers<ContextType = any, ParentType extends ResolversParentTypes['Idea'] = ResolversParentTypes['Idea']> = {
-  archived?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  closed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   comments?: Resolver<Maybe<Array<ResolversTypes['Comment']>>, ParentType, ContextType>;
   consensus?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/nouns-api/src/graphql/schemas/schema.graphql
+++ b/packages/nouns-api/src/graphql/schemas/schema.graphql
@@ -113,7 +113,7 @@ type Idea {
   createdAt: String!
   ideaStats: IdeaStats
   tags: [IdeaTags!]
-  archived: Boolean!
+  closed: Boolean!
   consensus: Float
 }
 

--- a/packages/nouns-api/src/graphql/schemas/schema.graphql
+++ b/packages/nouns-api/src/graphql/schemas/schema.graphql
@@ -113,6 +113,8 @@ type Idea {
   createdAt: String!
   ideaStats: IdeaStats
   tags: [IdeaTags!]
+  archived: Boolean!
+  consensus: Float
 }
 
 # Enums

--- a/packages/nouns-api/src/graphql/utils/queryUtils.ts
+++ b/packages/nouns-api/src/graphql/utils/queryUtils.ts
@@ -64,6 +64,6 @@ export const DATE_FILTERS: { [key: string]: any } = {
   },
 };
 
-export const getIsArchived = (idea: any) => {
+export const getIsClosed = (idea: any) => {
   return moment(idea.createdAt).isBefore(moment().subtract(7, 'days').toISOString());
 };

--- a/packages/nouns-api/src/graphql/utils/queryUtils.ts
+++ b/packages/nouns-api/src/graphql/utils/queryUtils.ts
@@ -63,3 +63,7 @@ export const DATE_FILTERS: { [key: string]: any } = {
     }),
   },
 };
+
+export const getIsArchived = (idea: any) => {
+  return moment(idea.createdAt).isBefore(moment().subtract(7, 'days').toISOString());
+};

--- a/packages/nouns-api/src/services/ideas.ts
+++ b/packages/nouns-api/src/services/ideas.ts
@@ -91,8 +91,6 @@ class IdeasService {
     date?: string;
   }) {
     try {
-      const totalSupply = await nounsTotalSupply();
-      console.log(totalSupply);
       const dateRange: any = DATE_FILTERS[date || 'ALL_TIME'].filterFn();
       const ideas = await prisma.idea.findMany({
         where: {

--- a/packages/nouns-api/src/services/ideas.ts
+++ b/packages/nouns-api/src/services/ideas.ts
@@ -28,12 +28,12 @@ const calculateVotes = (votes: any) => {
   return count;
 };
 
-const calculateConsensus = (idea: Idea) => {
+const calculateConsensus = (idea: Idea, voteCount: number) => {
   if (!idea.tokenSupplyOnCreate) {
     return undefined;
   }
 
-  const consensus = (idea.votecount / idea.tokenSupplyOnCreate) * 100;
+  const consensus = (voteCount / idea.tokenSupplyOnCreate) * 100;
   return Math.min(Math.max(Math.floor(consensus), 0), 100);
 };
 
@@ -115,7 +115,7 @@ class IdeasService {
       const ideaData = ideas
         .map((idea: any) => {
           const votecount = calculateVotes(idea.votes);
-          const consensus = calculateConsensus(idea);
+          const consensus = calculateConsensus(idea, votecount);
           const closed = getIsClosed(idea);
 
           return { ...idea, votecount, consensus, closed };
@@ -160,10 +160,11 @@ class IdeasService {
         throw new Error('Idea not found');
       }
 
-      const consensus = calculateConsensus(idea);
+      const votecount = calculateVotes(idea.votes);
+      const consensus = calculateConsensus(idea, votecount);
       const closed = getIsClosed(idea);
 
-      const ideaData = { ...idea, closed, consensus, votecount: calculateVotes(idea.votes) };
+      const ideaData = { ...idea, closed, consensus, votecount };
 
       return ideaData;
     } catch (e: any) {

--- a/packages/nouns-api/src/utils/utils.ts
+++ b/packages/nouns-api/src/utils/utils.ts
@@ -9,3 +9,12 @@ export const nounTokenCount = async (account: string) => {
   }
   return data?.toNumber();
 };
+
+export const nounsTotalSupply = async () => {
+  const data = await tryF(() => nounsTokenContract.totalSupply());
+  if (isError(data)) {
+    console.error(`Error fetching total supply`);
+    return;
+  }
+  return data?.toNumber();
+};

--- a/packages/nouns-webapp/src/components/IdeaCard/index.tsx
+++ b/packages/nouns-webapp/src/components/IdeaCard/index.tsx
@@ -24,7 +24,7 @@ const IdeaCard = ({
   const breakpoint = useBreakpoint();
   const history = useHistory();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const { id, tldr, title, creatorId, votecount: voteCount, votes, createdAt, _count } = idea;
+  const { id, tldr, title, creatorId, votes, createdAt, _count, archived } = idea;
   const isMobile = breakpoint === 'S';
 
   const ens = useReverseENSLookUp(creatorId);
@@ -40,11 +40,9 @@ const IdeaCard = ({
         </span>
         <div className="flex justify-self-end">
           <IdeaVoteControls
-            id={id}
+            idea={idea}
             voteOnIdea={voteOnIdea}
             nounBalance={nounBalance}
-            voteCount={voteCount}
-            votes={votes}
             withAvatars={!isMobile}
           />
         </div>
@@ -64,11 +62,9 @@ const IdeaCard = ({
       <span className="text-[#212529] font-normal text-2xl flex flex-1 lodrina ml-6">{title}</span>
       <div className="flex justify-self-end">
         <IdeaVoteControls
-          id={id}
+          idea={idea}
           voteOnIdea={voteOnIdea}
           nounBalance={nounBalance}
-          voteCount={voteCount}
-          votes={votes}
           withAvatars={!isMobile}
         />
       </div>
@@ -97,7 +93,7 @@ const IdeaCard = ({
                 _count?.comments === 1
                   ? `${_count?.comments} comment`
                   : `${_count?.comments || 0} comments`
-              }`}
+              } ${archived ? '| archived' : ''}`}
             </span>
             <span className="flex justify-self-end text-[#2b83f6] text-sm font-bold flex justify-end">
               <span

--- a/packages/nouns-webapp/src/components/IdeaCard/index.tsx
+++ b/packages/nouns-webapp/src/components/IdeaCard/index.tsx
@@ -24,7 +24,7 @@ const IdeaCard = ({
   const breakpoint = useBreakpoint();
   const history = useHistory();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const { id, tldr, title, creatorId, votes, createdAt, _count, archived } = idea;
+  const { id, tldr, title, creatorId, votes, createdAt, _count, closed } = idea;
   const isMobile = breakpoint === 'S';
 
   const ens = useReverseENSLookUp(creatorId);
@@ -93,7 +93,7 @@ const IdeaCard = ({
                 _count?.comments === 1
                   ? `${_count?.comments} comment`
                   : `${_count?.comments || 0} comments`
-              } ${archived ? '| archived' : ''}`}
+              } ${closed ? '| closed' : ''}`}
             </span>
             <span className="flex justify-self-end text-[#2b83f6] text-sm font-bold flex justify-end">
               <span

--- a/packages/nouns-webapp/src/components/IdeaVoteControls/index.tsx
+++ b/packages/nouns-webapp/src/components/IdeaVoteControls/index.tsx
@@ -3,6 +3,7 @@ import { Idea, Vote } from '../../hooks/useIdeas';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretUp, faCaretDown } from '@fortawesome/free-solid-svg-icons';
 import Davatar from '@davatar/react';
+import { getIdea_getIdea } from '../../propLot/graphql/__generated__/getIdea';
 
 const IdeaVoteControls = ({
   idea,
@@ -10,12 +11,12 @@ const IdeaVoteControls = ({
   nounBalance,
   withAvatars = false,
 }: {
-  idea: Idea;
+  idea: Idea | getIdea_getIdea;
   voteOnIdea: (args: any) => void;
   nounBalance: number;
   withAvatars?: boolean;
 }) => {
-  const { id, votes, votecount: voteCount, archived } = idea;
+  const { id, votes, votecount: voteCount, closed } = idea;
   const { account, library: provider } = useEthers();
   const hasVotes = nounBalance > 0;
 
@@ -54,7 +55,7 @@ const IdeaVoteControls = ({
           onClick={e => {
             // this prevents the click from bubbling up and opening / closing the hidden section
             e.stopPropagation();
-            if (hasVotes && !userHasUpVote && !archived) {
+            if (hasVotes && !userHasUpVote && !closed) {
               vote(1);
             }
           }}
@@ -67,7 +68,7 @@ const IdeaVoteControls = ({
           icon={faCaretDown}
           onClick={e => {
             e.stopPropagation();
-            if (hasVotes && !userHasDownVote && !archived) {
+            if (hasVotes && !userHasDownVote && !closed) {
               vote(-1);
             }
           }}

--- a/packages/nouns-webapp/src/components/IdeaVoteControls/index.tsx
+++ b/packages/nouns-webapp/src/components/IdeaVoteControls/index.tsx
@@ -1,24 +1,21 @@
 import { useEthers } from '@usedapp/core';
-import { Vote } from '../../hooks/useIdeas';
+import { Idea, Vote } from '../../hooks/useIdeas';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretUp, faCaretDown } from '@fortawesome/free-solid-svg-icons';
 import Davatar from '@davatar/react';
 
 const IdeaVoteControls = ({
-  id,
-  votes,
+  idea,
   voteOnIdea,
   nounBalance,
-  voteCount,
   withAvatars = false,
 }: {
-  id: number;
-  votes?: Vote[];
+  idea: Idea;
   voteOnIdea: (args: any) => void;
   nounBalance: number;
-  voteCount: number;
   withAvatars?: boolean;
 }) => {
+  const { id, votes, votecount: voteCount, archived } = idea;
   const { account, library: provider } = useEthers();
   const hasVotes = nounBalance > 0;
 
@@ -57,7 +54,7 @@ const IdeaVoteControls = ({
           onClick={e => {
             // this prevents the click from bubbling up and opening / closing the hidden section
             e.stopPropagation();
-            if (hasVotes && !userHasUpVote) {
+            if (hasVotes && !userHasUpVote && !archived) {
               vote(1);
             }
           }}
@@ -70,7 +67,7 @@ const IdeaVoteControls = ({
           icon={faCaretDown}
           onClick={e => {
             e.stopPropagation();
-            if (hasVotes && !userHasDownVote) {
+            if (hasVotes && !userHasDownVote && !archived) {
               vote(-1);
             }
           }}

--- a/packages/nouns-webapp/src/hooks/useIdeas.ts
+++ b/packages/nouns-webapp/src/hooks/useIdeas.ts
@@ -47,7 +47,7 @@ export interface Idea {
   comments?: Comment[];
   votecount: number;
   createdAt: string;
-  archived: boolean;
+  closed: boolean;
   _count?: {
     comments: number;
   };

--- a/packages/nouns-webapp/src/hooks/useIdeas.ts
+++ b/packages/nouns-webapp/src/hooks/useIdeas.ts
@@ -47,6 +47,7 @@ export interface Idea {
   comments?: Comment[];
   votecount: number;
   createdAt: string;
+  archived: boolean;
   _count?: {
     comments: number;
   };

--- a/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
+++ b/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
@@ -108,12 +108,12 @@ const Comment = ({
   comment,
   hasNouns,
   level,
-  isArchived,
+  isIdeaClosed,
 }: {
   comment: CommentType;
   hasNouns: boolean;
   level: number;
-  isArchived: boolean;
+  isIdeaClosed: boolean;
 }) => {
   const { id } = useParams() as { id: string };
   const [isReply, setIsReply] = useState<boolean>(false);
@@ -176,7 +176,7 @@ const Comment = ({
                   comment={reply}
                   hasNouns={hasNouns}
                   level={level + 1}
-                  isArchived={isArchived}
+                  isIdeaClosed={isIdeaClosed}
                 />
               </div>
             );
@@ -184,7 +184,7 @@ const Comment = ({
         </div>
       )}
 
-      {isReply && !isArchived && (
+      {isReply && !isIdeaClosed && (
         <CommentInput
           value={reply}
           setValue={setReply}
@@ -268,12 +268,12 @@ const IdeaPage = () => {
             <div className="flex flex-row justify-between items-center">
               <h1 className="mb-0 lodrina">{data.getIdea.title}</h1>
               <div className="flex flex-row justify-end">
-              <IdeaVoteControls
-                idea={data.getIdea}
-                voteOnIdea={castVote}
-                nounBalance={nounBalance}
-                withAvatars
-              />
+                <IdeaVoteControls
+                  idea={data.getIdea}
+                  voteOnIdea={castVote}
+                  nounBalance={nounBalance}
+                  withAvatars
+                />
               </div>
             </div>
             {data.getIdea.tags && data.getIdea.tags.length > 0 && (
@@ -313,7 +313,9 @@ const IdeaPage = () => {
         <div className="flex flex-1 font-bold text-sm text-[#8c8d92] mt-12">
           {`${ens || shortAddress} | ${
             creatorLilNoun === 1 ? `${creatorLilNoun} lil noun` : `${creatorLilNoun} lil nouns`
-          } | ${moment(parseInt(data.getIdea.createdAt)).format('MMM Do YYYY')} ${data.getIdea.archived ? '| archived' : ''}`}
+          } | ${moment(parseInt(data.getIdea.createdAt)).format('MMM Do YYYY')} ${
+            data.getIdea.closed ? '| closed' : ''
+          }`}
         </div>
 
         <div className="mt-2 mb-2">
@@ -328,7 +330,7 @@ const IdeaPage = () => {
           </div>
         ) : (
           <>
-            {!idea.archived && (
+            {!data.getIdea.closed && (
               <CommentInput
                 value={comment}
                 setValue={setComment}
@@ -344,7 +346,7 @@ const IdeaPage = () => {
                     key={`comment-${comment.id}`}
                     hasNouns={hasNouns}
                     level={1}
-                    isArchived={idea.archived}
+                    isIdeaClosed={!!data.getIdea?.closed}
                   />
                 );
               })}

--- a/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
+++ b/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
@@ -108,10 +108,12 @@ const Comment = ({
   comment,
   hasNouns,
   level,
+  isArchived,
 }: {
   comment: CommentType;
   hasNouns: boolean;
   level: number;
+  isArchived: boolean;
 }) => {
   const { id } = useParams() as { id: string };
   const [isReply, setIsReply] = useState<boolean>(false);
@@ -170,14 +172,19 @@ const Comment = ({
           {comment.replies?.map(reply => {
             return (
               <div className="ml-8" key={`replies-${reply.id}`}>
-                <Comment comment={reply} hasNouns={hasNouns} level={level + 1} />
+                <Comment
+                  comment={reply}
+                  hasNouns={hasNouns}
+                  level={level + 1}
+                  isArchived={isArchived}
+                />
               </div>
             );
           })}
         </div>
       )}
 
-      {isReply && (
+      {isReply && !isArchived && (
         <CommentInput
           value={reply}
           setValue={setReply}
@@ -261,14 +268,12 @@ const IdeaPage = () => {
             <div className="flex flex-row justify-between items-center">
               <h1 className="mb-0 lodrina">{data.getIdea.title}</h1>
               <div className="flex flex-row justify-end">
-                <IdeaVoteControls
-                  id={data.getIdea.id}
-                  voteOnIdea={castVote}
-                  nounBalance={nounBalance}
-                  voteCount={data.getIdea.votecount ?? 0}
-                  votes={data.getIdea.votes ?? []}
-                  withAvatars
-                />
+              <IdeaVoteControls
+                idea={data.getIdea}
+                voteOnIdea={castVote}
+                nounBalance={nounBalance}
+                withAvatars
+              />
               </div>
             </div>
             {data.getIdea.tags && data.getIdea.tags.length > 0 && (
@@ -308,7 +313,7 @@ const IdeaPage = () => {
         <div className="flex flex-1 font-bold text-sm text-[#8c8d92] mt-12">
           {`${ens || shortAddress} | ${
             creatorLilNoun === 1 ? `${creatorLilNoun} lil noun` : `${creatorLilNoun} lil nouns`
-          } | ${moment(parseInt(data.getIdea.createdAt)).format('MMM Do YYYY')}`}
+          } | ${moment(parseInt(data.getIdea.createdAt)).format('MMM Do YYYY')} ${data.getIdea.archived ? '| archived' : ''}`}
         </div>
 
         <div className="mt-2 mb-2">
@@ -323,12 +328,14 @@ const IdeaPage = () => {
           </div>
         ) : (
           <>
-            <CommentInput
-              value={comment}
-              setValue={setComment}
-              hasNouns={hasNouns}
-              onSubmit={submitComment}
-            />
+            {!idea.archived && (
+              <CommentInput
+                value={comment}
+                setValue={setComment}
+                hasNouns={hasNouns}
+                onSubmit={submitComment}
+              />
+            )}
             <div className="mt-12 space-y-8">
               {comments?.map(comment => {
                 return (
@@ -337,6 +344,7 @@ const IdeaPage = () => {
                     key={`comment-${comment.id}`}
                     hasNouns={hasNouns}
                     level={1}
+                    isArchived={idea.archived}
                   />
                 );
               })}

--- a/packages/nouns-webapp/src/propLot/components/IdeaRow/index.tsx
+++ b/packages/nouns-webapp/src/propLot/components/IdeaRow/index.tsx
@@ -16,17 +16,7 @@ const IdeaRow = ({ idea, nounBalance }: { idea: Idea; nounBalance: number }) => 
   const breakpoint = useBreakpoint();
   const history = useHistory();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const {
-    id,
-    tldr,
-    title,
-    creatorId,
-    votecount: voteCount,
-    votes,
-    createdAt,
-    ideaStats,
-    tags,
-  } = idea;
+  const { id, tldr, title, creatorId, votes, createdAt, ideaStats, tags } = idea;
   const isMobile = breakpoint === 'S';
 
   const ens = useReverseENSLookUp(creatorId);
@@ -42,10 +32,8 @@ const IdeaRow = ({ idea, nounBalance }: { idea: Idea; nounBalance: number }) => 
         </span>
         <div className="flex justify-self-end">
           <IdeaVoteControls
-            id={id}
+            idea={idea}
             nounBalance={nounBalance}
-            voteCount={voteCount}
-            votes={votes || []}
             withAvatars={!isMobile}
             refetchPropLotOnVote
           />
@@ -102,10 +90,8 @@ const IdeaRow = ({ idea, nounBalance }: { idea: Idea; nounBalance: number }) => 
       </div>
       <div className="flex justify-self-end">
         <IdeaVoteControls
-          id={id}
+          idea={idea}
           nounBalance={nounBalance}
-          voteCount={voteCount}
-          votes={votes || []}
           withAvatars={!isMobile}
           refetchPropLotOnVote
         />

--- a/packages/nouns-webapp/src/propLot/components/IdeaVoteControls/index.tsx
+++ b/packages/nouns-webapp/src/propLot/components/IdeaVoteControls/index.tsx
@@ -10,27 +10,23 @@ import { useAuth } from '../../../hooks/useAuth';
 import propLotClient from '../../graphql/config';
 import { SUBMIT_VOTE_MUTATION } from '../../graphql/propLotMutations';
 
-import {
-  submitIdeaVote,
-  submitIdeaVote_submitIdeaVote as Vote,
-} from '../../graphql/__generated__/submitIdeaVote';
+import { submitIdeaVote } from '../../graphql/__generated__/submitIdeaVote';
+import { getPropLot_propLot_ideas as Idea } from '../../graphql/__generated__/getPropLot';
+
 import { useEffect, useState } from 'react';
 
 const IdeaVoteControls = ({
-  id,
-  votes,
+  idea,
   nounBalance,
-  voteCount,
   withAvatars = false,
   refetchPropLotOnVote = false,
 }: {
-  id: number;
-  votes?: Vote[];
+  idea: Idea;
   nounBalance: number;
-  voteCount: number;
   withAvatars?: boolean;
   refetchPropLotOnVote?: boolean;
 }) => {
+  const { id, votecount: voteCount, archived, votes } = idea;
   const { account, library: provider } = useEthers();
   const { getAuthHeader, isLoggedIn, triggerSignIn } = useAuth();
   const { setError, error: errorModalVisible } = useApiError();
@@ -132,7 +128,7 @@ const IdeaVoteControls = ({
           onClick={e => {
             // this prevents the click from bubbling up and opening / closing the hidden section
             e.stopPropagation();
-            if (hasVotes && !userHasUpVote && !loading) {
+            if (hasVotes && !userHasUpVote && !loading && !archived) {
               vote(1);
             }
           }}
@@ -145,7 +141,7 @@ const IdeaVoteControls = ({
           icon={faCaretDown}
           onClick={e => {
             e.stopPropagation();
-            if (hasVotes && !userHasDownVote && !loading) {
+            if (hasVotes && !userHasDownVote && !loading && !archived) {
               vote(-1);
             }
           }}

--- a/packages/nouns-webapp/src/propLot/components/IdeaVoteControls/index.tsx
+++ b/packages/nouns-webapp/src/propLot/components/IdeaVoteControls/index.tsx
@@ -26,7 +26,7 @@ const IdeaVoteControls = ({
   withAvatars?: boolean;
   refetchPropLotOnVote?: boolean;
 }) => {
-  const { id, votecount: voteCount, archived, votes } = idea;
+  const { id, votecount: voteCount, closed, votes } = idea;
   const { account, library: provider } = useEthers();
   const { getAuthHeader, isLoggedIn, triggerSignIn } = useAuth();
   const { setError, error: errorModalVisible } = useApiError();
@@ -128,7 +128,7 @@ const IdeaVoteControls = ({
           onClick={e => {
             // this prevents the click from bubbling up and opening / closing the hidden section
             e.stopPropagation();
-            if (hasVotes && !userHasUpVote && !loading && !archived) {
+            if (hasVotes && !userHasUpVote && !loading && !closed) {
               vote(1);
             }
           }}
@@ -141,7 +141,7 @@ const IdeaVoteControls = ({
           icon={faCaretDown}
           onClick={e => {
             e.stopPropagation();
-            if (hasVotes && !userHasDownVote && !loading && !archived) {
+            if (hasVotes && !userHasDownVote && !loading && !closed) {
               vote(-1);
             }
           }}

--- a/packages/nouns-webapp/src/propLot/graphql/__generated__/getIdea.ts
+++ b/packages/nouns-webapp/src/propLot/graphql/__generated__/getIdea.ts
@@ -45,6 +45,8 @@ export interface getIdea_getIdea {
   votecount: number;
   createdAt: string;
   ideaStats: getIdea_getIdea_ideaStats | null;
+  closed: boolean;
+  consensus: number | null;
   tags: getIdea_getIdea_tags[] | null;
   votes: getIdea_getIdea_votes[] | null;
 }

--- a/packages/nouns-webapp/src/propLot/graphql/__generated__/getPropLot.ts
+++ b/packages/nouns-webapp/src/propLot/graphql/__generated__/getPropLot.ts
@@ -45,6 +45,8 @@ export interface getPropLot_propLot_ideas {
   votecount: number;
   createdAt: string;
   ideaStats: getPropLot_propLot_ideas_ideaStats | null;
+  archived: boolean;
+  consensus: number | null;
   tags: getPropLot_propLot_ideas_tags[] | null;
   votes: getPropLot_propLot_ideas_votes[] | null;
 }

--- a/packages/nouns-webapp/src/propLot/graphql/__generated__/getPropLot.ts
+++ b/packages/nouns-webapp/src/propLot/graphql/__generated__/getPropLot.ts
@@ -45,7 +45,7 @@ export interface getPropLot_propLot_ideas {
   votecount: number;
   createdAt: string;
   ideaStats: getPropLot_propLot_ideas_ideaStats | null;
-  archived: boolean;
+  closed: boolean;
   consensus: number | null;
   tags: getPropLot_propLot_ideas_tags[] | null;
   votes: getPropLot_propLot_ideas_votes[] | null;

--- a/packages/nouns-webapp/src/propLot/graphql/ideaQuery.ts
+++ b/packages/nouns-webapp/src/propLot/graphql/ideaQuery.ts
@@ -13,6 +13,8 @@ export const GET_IDEA_QUERY = gql`
       ideaStats {
         comments
       }
+      closed
+      consensus
       tags {
         type
         label

--- a/packages/nouns-webapp/src/propLot/graphql/propLotQuery.ts
+++ b/packages/nouns-webapp/src/propLot/graphql/propLotQuery.ts
@@ -14,7 +14,7 @@ export const GET_PROPLOT_QUERY = gql`
         ideaStats {
           comments
         }
-        archived
+        closed
         consensus
         tags {
           type

--- a/packages/nouns-webapp/src/propLot/graphql/propLotQuery.ts
+++ b/packages/nouns-webapp/src/propLot/graphql/propLotQuery.ts
@@ -14,6 +14,8 @@ export const GET_PROPLOT_QUERY = gql`
         ideaStats {
           comments
         }
+        archived
+        consensus
         tags {
           type
           label

--- a/packages/nouns-webapp/src/propLot/graphql/proplot-schema.json
+++ b/packages/nouns-webapp/src/propLot/graphql/proplot-schema.json
@@ -1276,10 +1276,49 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "archived",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "consensus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float",
+        "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+        "specifiedByUrl": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/nouns-webapp/src/propLot/graphql/proplot-schema.json
+++ b/packages/nouns-webapp/src/propLot/graphql/proplot-schema.json
@@ -1278,7 +1278,7 @@
             "deprecationReason": null
           },
           {
-            "name": "archived",
+            "name": "closed",
             "description": null,
             "args": [],
             "type": {


### PR DESCRIPTION
Adding some logic to set the Archived status on an idea when 7 days have passed, this is a dynamic value that i'm not saving in the DB as this would probably require a cron job? This solution can be extended to support manual archiving too when/if we add that.

Calculating community consensus by looking at the % of upvotes on an idea against the current token supply.

### Issue:

The consensus is currently dynamic but i'm wondering if it's better to fetch and save the current token supply against an idea at the time the idea is created. This would enable us to show how much consensus an idea gained at the time for historical context.
It would however introduce an issue where the token supply continues to inflate between creation + archiving and as we don't limit tokens that can vote by blocks it's possible the consensus could be a little inflated by the time an idea gets archived. Seems like it would be a pretty minor impact though, how many tokens do we create over 7 days?

### Update:

I've decided to log the current token supply when creating an idea to the `tokenSupplyOnCreate` property in the prisma schema. This value can then be used to calculate the consensus and lock it in after an idea has been archived, voting has been disabled and token supply continues to grow. This way we have a permanent record of community consensus for at the time of the idea.