### PR TITLE
Update user queries to include userAggregations if the queries reques…

### DIFF
--- a/packages/nouns-api/src/graphql/resolvers/UserResolvers.ts
+++ b/packages/nouns-api/src/graphql/resolvers/UserResolvers.ts
@@ -1,28 +1,65 @@
 import UserService from '../../services/user';
 
 import { IResolvers } from '@graphql-tools/utils';
-import { QueryGetUserArgs, User } from '../generated';
+import { QueryGetUserArgs, User, Vote } from '../generated';
+
+type UserWithAggregations = User & { userAggregations?: any };
 
 const resolvers: IResolvers = {
   Query: {
-    getAllUsers: async (_parent: any): Promise<User[]> => {
-      const users: User[] = await UserService.allUsers();
+    getAllUsers: async (
+      _parent: any,
+      _args: any,
+      _context: any,
+      info,
+    ): Promise<UserWithAggregations[]> => {
+      const users: UserWithAggregations[] = await UserService.allUsers();
+
+      const queryInfo = info.fieldNodes.find(node => node.name.value === 'getAllUsers');
+      const userStatsField = queryInfo?.selectionSet?.selections.find(
+        (selection: any) => selection.name.value === 'userStats',
+      );
+      // only fetch user aggregations if requested
+      if (Boolean(userStatsField)) {
+        for await (const user of users) {
+          const aggregations = await UserService.getUserAggregations({ wallet: user.wallet });
+          user.userAggregations = aggregations;
+        }
+      }
+
       return users;
     },
-    getUser: async (_parent: any, args: QueryGetUserArgs): Promise<User> => {
-      const users: User = await UserService.getUser(args.options.wallet as string);
-      return users;
+    getUser: async (
+      _parent: any,
+      args: QueryGetUserArgs,
+      _context: any,
+      info,
+    ): Promise<UserWithAggregations> => {
+      const user: UserWithAggregations = await UserService.getUser(args.options.wallet as string);
+
+      const queryInfo = info.fieldNodes.find(node => node.name.value === 'getUser');
+      const userStatsField = queryInfo?.selectionSet?.selections.find(
+        (selection: any) => selection.name.value === 'userStats',
+      );
+      if (Boolean(userStatsField)) {
+        const aggregations = await UserService.getUserAggregations({ wallet: args.options.wallet });
+        user.userAggregations = aggregations;
+      }
+
+      return user;
     },
   },
   User: {
     userStats: root => {
       return {
-        totalVotes: root.votes?.length,
-        totalComments: root._count?.comments,
-        totalIdeas: root._count?.ideas,
-        netVotesReceived: root.userAggregations?.netVotes,
-        upvotesReceived: root.userAggregations?.netUpvotes,
-        downvotesReceived: root.userAggregations?.netDownvotes,
+        totalVotes: root.votes?.length || 0, // Number of votes in total applied
+        totalUpvotes: root.votes?.filter((vote: Vote) => vote.direction === 1).length || 0, // Number of upvotes a user has applied
+        totalDownvotes: root.votes?.filter((vote: Vote) => vote.direction === -1).length || 0, // Number of downvotes a user has applied
+        totalComments: root._count?.comments || 0, // Number of comments left in total
+        totalIdeas: root._count?.ideas || 0, // Number of idea submissions in total
+        netVotesReceived: root.userAggregations?.netVotes || 0, // Net votes received on own users ideas
+        upvotesReceived: root.userAggregations?.netUpvotes || 0, // Net upvotes received on own users ideas
+        downvotesReceived: root.userAggregations?.netDownvotes || 0, // Net downvotes received on own users ideas
       };
     },
   },

--- a/packages/nouns-api/src/graphql/schemas/schema.graphql
+++ b/packages/nouns-api/src/graphql/schemas/schema.graphql
@@ -86,13 +86,21 @@ type PropLotResponseMetadata {
 # Raw Data Types
 
 type UserStats {
+  # Number of votes in total applied
   totalVotes: Int
+  # Number of upvotes a user has applied
   totalUpvotes: Int
+  # Number of downvotes a user has applied
   totalDownvotes: Int
+  # Number of comments left in total
   totalComments: Int
+  # Number of idea submissions in total
   totalIdeas: Int
+  # Net votes received on own users ideas
   netVotesReceived: Int
+  # Net downvotes received on own users ideas
   downvotesReceived: Int
+  # Net upvotes received on own users ideas
   upvotesReceived: Int
 }
 

--- a/packages/nouns-api/src/services/user.ts
+++ b/packages/nouns-api/src/services/user.ts
@@ -42,6 +42,11 @@ class UserService {
     try {
       const users = await prisma.user.findMany({
         include: {
+          votes: {
+            include: {
+              idea: true,
+            },
+          },
           _count: {
             select: { comments: true, votes: true, ideas: true },
           },


### PR DESCRIPTION
Update user queries to include userAggregations only if the queries request userStats. Another community member mentioned that the user queries which they're using for their own project didn't have all the data present.

I changed the query data slightly when building out V2 and profiles but forgot to update these queries as we don't use them for proplot specifically. This should fix it.